### PR TITLE
Add include guard to RGBmatrixPanel.h

### DIFF
--- a/RGBmatrixPanel.h
+++ b/RGBmatrixPanel.h
@@ -1,3 +1,6 @@
+#ifndef RGBMATRIXPANEL_H
+#define RGBMATRIXPANEL_H
+
 #if ARDUINO >= 100
  #include "Arduino.h"
 #else
@@ -58,3 +61,4 @@ class RGBmatrixPanel : public Adafruit_GFX {
   volatile uint8_t *buffptr;
 };
 
+#endif // RGBMATRIXPANEL_H


### PR DESCRIPTION
I departed from the convention established by [gamma.h](https://github.com/adafruit/RGB-matrix-Panel/blob/master/gamma.h#L1) because the C++ standard says that any name which begins with an underscore followed by an uppercase letter is reserved.