### PR TITLE
Added pointer to SmartMatrix::GFX for 32bit chips not supported

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,10 @@ Place the RGBmatrixPanel library folder your arduinosketchfolder/libraries/ fold
 You may need to create the libraries subfolder if its your first library. 
 Restart the IDE.
 
-
 We also have a great tutorial on Arduino library installation at:
 http://learn.adafruit.com/adafruit-all-about-arduino-libraries-install-use
+
+If you need support for RGB888 (24bpp) and need to/can run on Teensy 3.1/3.2/3.5/3.6 or 
+ESP32 chips (not supported by RGB-matrix-Panel), please look at
+https://github.com/marcmerlin/SmartMatrix_GFX which offers a GFX compatibility layer on
+top of https://github.com/pixelmatix/SmartMatrix


### PR DESCRIPTION
No code changes, just a doc update.
Adafruit hardware that benefits:
https://www.adafruit.com/product/3405

and your 64x64 panel which you state requires a rPi but works fine with SmartMatrix::GFX + SmartMatrix
https://www.adafruit.com/product/3649