### PR TITLE
esp32: fix bug when WiFi is used simultaneously

### DIFF
--- a/RGBmatrixPanel.cpp
+++ b/RGBmatrixPanel.cpp
@@ -774,7 +774,12 @@ void RGBmatrixPanel::updateDisplay(void) {
   while(TIMER->COUNT16.STATUS.bit.SYNCBUSY);
 #endif // SAMD21
 #elif defined(ARDUINO_ARCH_ESP32)
-  timer_set_alarm_value(TIMER_GROUP_1, TIMER_0, duration);
+  static timg_dev_t *TG[2] = {&TIMERG0, &TIMERG1};
+  static portMUX_TYPE timer_spinlock[TIMER_GROUP_MAX] = {portMUX_INITIALIZER_UNLOCKED, portMUX_INITIALIZER_UNLOCKED};
+  portENTER_CRITICAL(&timer_spinlock[TIMER_GROUP_1]);
+  TG[TIMER_GROUP_1]->hw_timer[TIMER_0].alarm_high = (uint32_t) (duration >> 32);
+  TG[TIMER_GROUP_1]->hw_timer[TIMER_0].alarm_low = (uint32_t) duration;
+  portEXIT_CRITICAL(&timer_spinlock[TIMER_GROUP_1]);
 #endif // ARDUINO_ARCH_SAMD
   *oeport  &= ~oemask;  // Re-enable output
   *latport &= ~latmask; // Latch down


### PR DESCRIPTION
timer_set_alarm_value does not seem to have the IRAM_FLAG set, so the application might crash, when timer_set_alarm_value is not found in the cache.