### PR TITLE
Fixed bug in wheel function for colors >= 16

### DIFF
--- a/examples/testshapes_32x64/testshapes_32x64.ino
+++ b/examples/testshapes_32x64/testshapes_32x64.ino
@@ -122,6 +122,6 @@ uint16_t Wheel(byte WheelPos) {
    return matrix.Color333(0, 7-WheelPos, WheelPos);
   } else {
    WheelPos -= 16;
-   return matrix.Color333(0, WheelPos, 7 - WheelPos);
+   return matrix.Color333(WheelPos, 0, 7 - WheelPos);
   }
 }


### PR DESCRIPTION
Fixed bug in wheel function that was causing colors go from B->G instead of B->R.