### PR TITLE
Nano 33 iot

### DIFF
--- a/RGBmatrixPanel.cpp
+++ b/RGBmatrixPanel.cpp
@@ -106,7 +106,11 @@ void RGBmatrixPanel::init(uint8_t rows, uint8_t a, uint8_t b, uint8_t c,
   ) {
 #if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_ESP32)
   // R1, G1, B1, R2, G2, B2 pins
-  static const uint8_t defaultrgbpins[] = { 2,3,4,5,6,7 };
+  #if defined(ARDUINO_SAMD_NANO_33_IOT)
+    static const uint8_t defaultrgbpins[] = { 4,5,6,7,8,9 };
+  #else
+    static const uint8_t defaultrgbpins[] = { 2,3,4,5,6,7 };
+  #endif
   memcpy(rgbpins, pinlist ? pinlist : defaultrgbpins, sizeof rgbpins);
 #if defined(ARDUINO_ARCH_SAMD)
   // All six RGB pins MUST be on the same PORT # as CLK
@@ -147,7 +151,7 @@ void RGBmatrixPanel::init(uint8_t rows, uint8_t a, uint8_t b, uint8_t c,
   addrbport = portOutputRegister(digitalPinToPort(b));
   addrbmask = digitalPinToBitMask(b);
   addrcport = portOutputRegister(digitalPinToPort(c));
-  addrcmask = digitalPinToBitMask(c); 
+  addrcmask = digitalPinToBitMask(c);
   plane     = nPlanes - 1;
   row       = nRows   - 1;
   swapflag  = false;
@@ -870,10 +874,10 @@ void RGBmatrixPanel::updateDisplay(void) {
         ((ptr[i+WIDTH*2] << 2) & 0x0C);
       CLKPORT = tick; // Clock lo
       CLKPORT = tock; // Clock hi
-    } 
+    }
 #elif defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_ESP32)
     for (int i=0; i<WIDTH; i++) {
-      byte b = 
+      byte b =
 	( ptr[i]         << 6)         |
         ((ptr[i+WIDTH]   << 4) & 0x30) |
         ((ptr[i+WIDTH*2] << 2) & 0x0C);
@@ -886,4 +890,3 @@ void RGBmatrixPanel::updateDisplay(void) {
 #endif
   }
 }
-

--- a/examples/PanelGFXDemo_16x32/PanelGFXDemo_16x32.ino
+++ b/examples/PanelGFXDemo_16x32/PanelGFXDemo_16x32.ino
@@ -21,6 +21,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/PanelGFXDemo_16x32/PanelGFXDemo_16x32.ino
+++ b/examples/PanelGFXDemo_16x32/PanelGFXDemo_16x32.ino
@@ -10,16 +10,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
-//#define CLK  8 // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
+#define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
-#define CLK 11   // USE THIS ON ARDUINO MEGA
-#define OE   9
+//#define CLK 11 // USE THIS ON ARDUINO MEGA
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1

--- a/examples/colorwheel_32x32/colorwheel_32x32.ino
+++ b/examples/colorwheel_32x32/colorwheel_32x32.ino
@@ -22,6 +22,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/colorwheel_32x32/colorwheel_32x32.ino
+++ b/examples/colorwheel_32x32/colorwheel_32x32.ino
@@ -11,16 +11,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1

--- a/examples/colorwheel_progmem_32x32/colorwheel_progmem_32x32.ino
+++ b/examples/colorwheel_progmem_32x32/colorwheel_progmem_32x32.ino
@@ -12,10 +12,22 @@
 #include <RGBmatrixPanel.h>
 #include "image.h" // Precomputed colorwheel image is here
 
+// Most of the signal pins are configurable, but the CLK pin has some
+// special constraints.  On 8-bit AVR boards it must be on PORTB...
+// Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
+// Pin 11 works on the Arduino Mega.
+// Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
+// Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
+// Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
+
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1

--- a/examples/colorwheel_progmem_32x32/colorwheel_progmem_32x32.ino
+++ b/examples/colorwheel_progmem_32x32/colorwheel_progmem_32x32.ino
@@ -26,6 +26,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/plasma_16x32/plasma_16x32.ino
+++ b/examples/plasma_16x32/plasma_16x32.ino
@@ -22,6 +22,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/plasma_16x32/plasma_16x32.ino
+++ b/examples/plasma_16x32/plasma_16x32.ino
@@ -11,16 +11,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1
@@ -126,4 +129,3 @@ void loop() {
 
   matrix.swapBuffers(false);
 }
-

--- a/examples/plasma_32x32/plasma_32x32.ino
+++ b/examples/plasma_32x32/plasma_32x32.ino
@@ -22,6 +22,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/plasma_32x32/plasma_32x32.ino
+++ b/examples/plasma_32x32/plasma_32x32.ino
@@ -11,16 +11,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1
@@ -121,4 +124,3 @@ void loop() {
   angle4 -= 0.15;
   hueShift += 2;
 }
-

--- a/examples/scrolltext_16x32/scrolltext_16x32.ino
+++ b/examples/scrolltext_16x32/scrolltext_16x32.ino
@@ -22,6 +22,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/scrolltext_16x32/scrolltext_16x32.ino
+++ b/examples/scrolltext_16x32/scrolltext_16x32.ino
@@ -11,16 +11,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1

--- a/examples/testcolors_16x32/testcolors_16x32.ino
+++ b/examples/testcolors_16x32/testcolors_16x32.ino
@@ -12,16 +12,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1
@@ -69,4 +72,3 @@ void setup() {
 void loop() {
   // Do nothing -- image doesn't change
 }
-

--- a/examples/testcolors_16x32/testcolors_16x32.ino
+++ b/examples/testcolors_16x32/testcolors_16x32.ino
@@ -23,6 +23,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/testshapes_16x32/testshapes_16x32.ino
+++ b/examples/testshapes_16x32/testshapes_16x32.ino
@@ -12,16 +12,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1

--- a/examples/testshapes_16x32/testshapes_16x32.ino
+++ b/examples/testshapes_16x32/testshapes_16x32.ino
@@ -23,6 +23,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/testshapes_32x32/testshapes_32x32.ino
+++ b/examples/testshapes_32x32/testshapes_32x32.ino
@@ -12,16 +12,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1

--- a/examples/testshapes_32x32/testshapes_32x32.ino
+++ b/examples/testshapes_32x32/testshapes_32x32.ino
@@ -23,6 +23,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/testshapes_32x64/testshapes_32x64.ino
+++ b/examples/testshapes_32x64/testshapes_32x64.ino
@@ -20,6 +20,7 @@
 #define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
+//#define CLK A6 // USE THIS ON NANO 33 IoT
 #define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
 //#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10

--- a/examples/testshapes_32x64/testshapes_32x64.ino
+++ b/examples/testshapes_32x64/testshapes_32x64.ino
@@ -9,16 +9,19 @@
 // Most of the signal pins are configurable, but the CLK pin has some
 // special constraints.  On 8-bit AVR boards it must be on PORTB...
 // Pin 8 works on the Arduino Uno & compatibles (e.g. Adafruit Metro),
-// Pin 11 works on the Arduino Mega.  On 32-bit SAMD boards it must be
-// on the same PORT as the RGB data pins (D2-D7)...
+// Pin 11 works on the Arduino Mega.
 // Pin 8 works on the Adafruit Metro M0 or Arduino Zero,
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
+// Pin A6 works on the Nano 33 IoT
+// On other 32-bit SAMD boards it must be on the same PORT as the RGB
+//   data pins (D2-D7)... Pin 8 works
 
-#define CLK  8   // USE THIS ON ADAFRUIT METRO M0, etc.
+#define CLK  8   // USE THIS ON ARDUINO UNO, ADAFRUIT METRO M0, etc.
 //#define CLK A4 // USE THIS ON METRO M4 (not M0)
 //#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define OE   9 // USE THIS ON EXCEPT ON NANO 33 IoT
+//#define OE 11 // USE THIS ON NANO 33 IoT
 #define LAT 10
 #define A   A0
 #define B   A1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RGB matrix Panel
-version=1.1.1
+version=1.1.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library and example code for the 16x32 RGB matrix panels in the shop


### PR DESCRIPTION
… from other SAMD boards

**Scope of change:** This change adds support for the Arduino Nano 33 IoT ("new" Nano board). Prior to this change, the current SAMD support fails on this board, as the hard-coded RGB data pins (2-7) are split across ports A and B. This change instead uses pins 4-9 on the Nano 33 IoT, requiring that the user set their CLK to any pin on port A. The remainder of the changes note this instruction in the example code, and provide an example define for CLK on pin A6. 

**Limitations:** 

- Changes to the RGB data pins for the Nano 33 IoT will need to be noted in tutorials using this library. 
- The prior example code also uses pin 9 for OE. To keep the RGB data wiring straightforward (contiguous pins 4-9), this pin should also be changed for the Nano 33 IoT, as noted in the examples. 
- The other (BLE) Nano 33 variant appears to have a different port mapping, and so the Nano 33 BLE will likely require a separate change if the prior SAMD support does not suffice. 

**Tests:** I have tested the example projects on the Nano 33 IoT, as well as my own custom uses of the library. 

Thank you for your work on this great library!
