### PR TITLE
feat: Add a width variable to the constructor for 16x32 panel

### DIFF
--- a/RGBmatrixPanel.cpp
+++ b/RGBmatrixPanel.cpp
@@ -157,12 +157,12 @@ void RGBmatrixPanel::init(uint8_t rows, uint8_t a, uint8_t b, uint8_t c,
 // Constructor for 16x32 panel:
 RGBmatrixPanel::RGBmatrixPanel(
   uint8_t a, uint8_t b, uint8_t c,
-  uint8_t clk, uint8_t lat, uint8_t oe, boolean dbuf
+  uint8_t clk, uint8_t lat, uint8_t oe, boolean dbuf, uint8_t width=32
 #if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_ESP32)
     ,uint8_t *pinlist
 #endif
-  ) : Adafruit_GFX(32, 16) {
-  init(8, a, b, c, clk, lat, oe, dbuf, 32
+  ) : Adafruit_GFX(width, 16) {
+  init(8, a, b, c, clk, lat, oe, dbuf, width
 #if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_ESP32)
     ,pinlist
 #endif

--- a/RGBmatrixPanel.h
+++ b/RGBmatrixPanel.h
@@ -21,7 +21,7 @@ class RGBmatrixPanel : public Adafruit_GFX {
 
   // Constructor for 16x32 panel:
   RGBmatrixPanel(uint8_t a, uint8_t b, uint8_t c,
-    uint8_t clk, uint8_t lat, uint8_t oe, boolean dbuf
+    uint8_t clk, uint8_t lat, uint8_t oe, boolean dbuf, uint8_t width=32
 #if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_ESP32)
     ,uint8_t *pinlist=NULL
 #endif


### PR DESCRIPTION
Tested on **two 16x32 RGB LED Matrix**,  **Arduino UNO, Arduino MEGA Board** 

Add width variable to the 16x32 panel constructor for used multiple panels .

![KakaoTalk_20200325_185834994](https://user-images.githubusercontent.com/37214452/77524435-ae9a0500-6eca-11ea-9554-2fb41d386ffb.jpg)
